### PR TITLE
Add check to skip tests

### DIFF
--- a/tests/testthat.R
+++ b/tests/testthat.R
@@ -3,4 +3,8 @@ library(namsor)
 
 httr::set_config(httr::config(ssl_verifypeer = 0L))
 
-test_check("namsor")
+if (Sys.getenv("API_KEY") == '') {
+  warnings("The environment variable `API_KEY` not setup properly. Tests Skipped")
+} else {
+  test_check("namsor")
+}


### PR DESCRIPTION
Add check to skip tests if API_KEY (environment variable) is not defined